### PR TITLE
Fix security configuration and restore authentication for protected event endpoints

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -27,6 +27,8 @@ docker run -d \
     --network event-mesh \
     --add-host auth.local:host-gateway \
     -p 8083:8083 \
+    -e SPRING_REDIS_HOST=redis \
+    -e SPRING_REDIS_PORT=6379 \
     -e SPRING_DATASOURCE_URL=jdbc:postgresql://event-database:5432/eventdb \
     -e SPRING_DATASOURCE_USERNAME=postgres \
     -e SPRING_DATASOURCE_PASSWORD=daroch \

--- a/src/main/java/com/daroch/event/config/SecurityConfig.java
+++ b/src/main/java/com/daroch/event/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.daroch.event.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 
@@ -10,13 +11,15 @@ public class SecurityConfig {
 
   @Bean
   SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-    http.securityMatcher("/**")
+    http.csrf(csrf -> csrf.disable())
         .authorizeHttpRequests(
             auth ->
-                auth.requestMatchers("/events/published", "/events/published/**")
+                auth.requestMatchers("/events/published", "/events/published/*")
                     .permitAll()
                     .anyRequest()
-                    .authenticated());
+                    .authenticated())
+        .oauth2ResourceServer(oauth -> oauth.jwt(Customizer.withDefaults()));
+
     return http.build();
   }
 }

--- a/src/main/java/com/daroch/event/controllers/EventController.java
+++ b/src/main/java/com/daroch/event/controllers/EventController.java
@@ -1,6 +1,8 @@
 package com.daroch.event.controllers;
 
 import com.daroch.event.domain.entities.Event;
+import com.daroch.event.dto.commands.CreateEventCommand;
+import com.daroch.event.dto.commands.UpdateEventCommand;
 import com.daroch.event.dto.request.CreateEventRequest;
 import com.daroch.event.dto.request.UpdateEventRequest;
 import com.daroch.event.dto.response.CreateEventResponse;
@@ -8,8 +10,6 @@ import com.daroch.event.dto.response.EventResponse;
 import com.daroch.event.mappers.EventMapper;
 import com.daroch.event.services.EventCommandService;
 import com.daroch.event.services.EventQueryService;
-import com.daroch.event.dto.commands.CreateEventCommand;
-import com.daroch.event.dto.commands.UpdateEventCommand;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -105,7 +105,9 @@ public class EventController {
    */
   @PatchMapping("/{eventId}")
   public ResponseEntity<EventResponse> updateEvent(
-      @AuthenticationPrincipal Jwt jwt, @Valid @RequestBody UpdateEventRequest updateEventRequest) {
+      @PathVariable UUID eventId,
+      @AuthenticationPrincipal Jwt jwt,
+      @Valid @RequestBody UpdateEventRequest updateEventRequest) {
 
     // Convert DTO → domain model for service layer
     UpdateEventCommand updateEventCommand =
@@ -115,7 +117,8 @@ public class EventController {
     UUID userId = parseUserId(jwt);
 
     // Delegate update logic to the service
-    Event updatedEvent = eventCommandService.updateEventForOrganizer(userId, updateEventCommand);
+    Event updatedEvent =
+        eventCommandService.updateEventForOrganizer(userId, eventId, updateEventCommand);
 
     // Convert the updated entity → response DTO
     EventResponse updateEventResponseDto = eventMapper.toEventResponseDto(updatedEvent);

--- a/src/main/java/com/daroch/event/dto/commands/UpdateEventCommand.java
+++ b/src/main/java/com/daroch/event/dto/commands/UpdateEventCommand.java
@@ -12,7 +12,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class UpdateEventCommand {
 
-  private UUID eventId;
   private String name;
   private String venue;
   private EventStatusEnum status;

--- a/src/main/java/com/daroch/event/dto/request/UpdateEventRequest.java
+++ b/src/main/java/com/daroch/event/dto/request/UpdateEventRequest.java
@@ -12,7 +12,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class UpdateEventRequest {
 
-  private UUID eventId;
   private String name;
   private String venue;
   private EventStatusEnum status;

--- a/src/main/java/com/daroch/event/services/EventCommandService.java
+++ b/src/main/java/com/daroch/event/services/EventCommandService.java
@@ -8,7 +8,7 @@ import java.util.UUID;
 public interface EventCommandService {
   Event createEvent(UUID organizerId, CreateEventCommand event);
 
-  Event updateEventForOrganizer(UUID organizerId, UpdateEventCommand event);
+  Event updateEventForOrganizer(UUID organizerId, UUID eventId, UpdateEventCommand event);
 
   void deleteEventForOrganizer(UUID organizerId, UUID eventId);
 }

--- a/src/main/java/com/daroch/event/services/impl/EventCommandServiceImpl.java
+++ b/src/main/java/com/daroch/event/services/impl/EventCommandServiceImpl.java
@@ -1,12 +1,12 @@
 package com.daroch.event.services.impl;
 
 import com.daroch.event.domain.entities.Event;
+import com.daroch.event.dto.commands.CreateEventCommand;
+import com.daroch.event.dto.commands.UpdateEventCommand;
 import com.daroch.event.exceptions.EventNotFoundException;
 import com.daroch.event.exceptions.EventUpdateException;
 import com.daroch.event.repositories.EventRepository;
 import com.daroch.event.services.EventCommandService;
-import com.daroch.event.dto.commands.CreateEventCommand;
-import com.daroch.event.dto.commands.UpdateEventCommand;
 import jakarta.transaction.Transactional;
 import java.util.Optional;
 import java.util.UUID;
@@ -72,19 +72,20 @@ public class EventCommandServiceImpl implements EventCommandService {
    */
   @Override
   @Transactional
-  public Event updateEventForOrganizer(UUID organizerId, UpdateEventCommand cmd) {
+  public Event updateEventForOrganizer(UUID organizerId, UUID eventId, UpdateEventCommand cmd) {
 
-    if (cmd.getEventId() == null) {
+    if (organizerId == null) {
+      throw new EventUpdateException("organizer Id cannot be null");
+    }
+    if (eventId == null) {
       throw new EventUpdateException("Event ID cannot be null");
     }
 
     Event event =
         eventRepository
-            .findByEventIdAndOrganizerId(cmd.getEventId(), organizerId)
+            .findByEventIdAndOrganizerId(eventId, organizerId)
             .orElseThrow(
-                () ->
-                    new EventNotFoundException(
-                        "Event with id '" + cmd.getEventId() + "' does not exist"));
+                () -> new EventNotFoundException("Event with id '" + eventId + "' does not exist"));
 
     if (cmd.getName() != null) {
       event.setName(cmd.getName());

--- a/src/test/java/com/daroch/event/services/impl/EventCommandServiceImplTests.java
+++ b/src/test/java/com/daroch/event/services/impl/EventCommandServiceImplTests.java
@@ -97,11 +97,12 @@ class EventCommandServiceImplTest {
       // Arrange
       UpdateEventCommand cmd = new UpdateEventCommand();
       UUID organizerId = UUID.randomUUID();
+      UUID eventId = null;
 
       // Act + Assert
       assertThrows(
           EventUpdateException.class,
-          () -> eventCommandService.updateEventForOrganizer(organizerId, cmd));
+          () -> eventCommandService.updateEventForOrganizer(organizerId, eventId, cmd));
 
       // Repository must not be touched on validation failure
       Mockito.verifyNoInteractions(eventRepository);
@@ -116,7 +117,6 @@ class EventCommandServiceImplTest {
       UUID eventId = UUID.randomUUID();
 
       UpdateEventCommand cmd = new UpdateEventCommand();
-      cmd.setEventId(eventId);
 
       Mockito.when(eventRepository.findByEventIdAndOrganizerId(eventId, organizerId))
           .thenReturn(Optional.empty());
@@ -124,7 +124,7 @@ class EventCommandServiceImplTest {
       // Act + Assert
       assertThrows(
           EventNotFoundException.class,
-          () -> eventCommandService.updateEventForOrganizer(organizerId, cmd));
+          () -> eventCommandService.updateEventForOrganizer(organizerId, eventId, cmd));
 
       // Ensure no save attempt is made
       Mockito.verify(eventRepository).findByEventIdAndOrganizerId(eventId, organizerId);
@@ -146,7 +146,6 @@ class EventCommandServiceImplTest {
       existingEvent.setStatus(EventStatusEnum.DRAFT);
 
       UpdateEventCommand cmd = new UpdateEventCommand();
-      cmd.setEventId(eventId);
       cmd.setName("New Name"); // should update
       cmd.setVenue(null); // should remain unchanged
       cmd.setStatus(EventStatusEnum.PUBLISHED);
@@ -159,7 +158,7 @@ class EventCommandServiceImplTest {
           .thenAnswer(invocation -> invocation.getArgument(0));
 
       // Act
-      Event result = eventCommandService.updateEventForOrganizer(organizerId, cmd);
+      Event result = eventCommandService.updateEventForOrganizer(organizerId, eventId, cmd);
 
       // Assert: returned entity reflects selective updates
       assertAll(


### PR DESCRIPTION
This PR fixes an issue where protected event endpoints were returning `403 Forbidden` even when a valid Bearer JWT was provided.

The problem was caused by incomplete JWT resource server configuration, which prevented Spring Security from properly authenticating requests.

Changes made:

* Updated the Spring Security configuration to correctly enable JWT authentication using the modern OAuth2 Resource Server setup
* Ensured protected endpoints now accept and validate Bearer tokens correctly
* Verified that public endpoints remain accessible without authentication
* Confirmed the update event endpoint works as expected for authenticated users

After this fix:

* Public endpoints continue to work without authentication
* Protected endpoints now work correctly with valid JWT tokens
* Unauthorized access is properly blocked

This restores the intended security behavior for the Event Service.